### PR TITLE
(fixed) fixed config example file error

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -3,7 +3,7 @@
 [template]
     path = "./templates"
 [database]
-    path = "./storage/db/go-whisper.db"
+    dsn = "./storage/db/go-whisper.db"
 [logger]
     path = "./storage/logs/common.log"
 [secure]


### PR DESCRIPTION
`database.dsn` is used in the code, but `database.path` is used in the config example file.